### PR TITLE
Add proxy mapping - so proxy passed in runTest is used for fetching results

### DIFF
--- a/lib/mapping.js
+++ b/lib/mapping.js
@@ -665,6 +665,9 @@ var options = {
       valid:
         /^(?:dot|spec|tap|xunit|list|progress|min|nyan|landing|json|doc|markdown|teamcity)$/,
     },
+    proxy: {
+      name: "proxy"
+    },
   },
   waterfall: {
     type: {


### PR DESCRIPTION
As mentioned in #31 , if a proxy option is passed to webpagetest runTest when running in a VPN env, it is used to invoke the test, but the polling of results fail because of the proxy option not being copied.  Adding the mapping ensures fetch results will also be successful in a VPN environment.