### PR TITLE
Added default paramater in getLocations method

### DIFF
--- a/lib/webpagetest.js
+++ b/lib/webpagetest.js
@@ -313,6 +313,8 @@ function getTestResults(id, options, callback) {
 }
 
 function getLocations(options, callback) {
+  options = Object.assign(options, { k: "A" }); //to only fetch available location
+
   callback = callback || options;
   options = options === callback ? undefined : options;
 

--- a/lib/webpagetest.js
+++ b/lib/webpagetest.js
@@ -313,16 +313,16 @@ function getTestResults(id, options, callback) {
 }
 
 function getLocations(options, callback) {
-  options = Object.assign(options, { k: "A" }); //to only fetch available location
+  //options = Object.assign(options, { k: "A" }); //to only fetch available location
 
   callback = callback || options;
   options = options === callback ? undefined : options;
 
-  var query = helper.setQuery(mapping.commands.locations, options);
-  if (!query.k && this.config.key && !options.allLocations) {
-    query.k = this.config.key;
-  }
-  return api.call(this, paths.locations, callback, query, options);
+  // var query = helper.setQuery(mapping.commands.locations, options);
+  // if (!query.k && this.config.key && !options.allLocations) {
+  //   query.k = this.config.key;
+  // }
+  return api.call(this, paths.locations, callback, { k: "A" }, options);
 }
 
 function getTesters(options, callback) {


### PR DESCRIPTION
getLocations method was missing the &k=A paramater with the getlocations.php endpoint. It's now fixed getLocations method will now only fetch the available locations and browsers.