### PR TITLE
Header User-Agent added

### DIFF
--- a/lib/webpagetest.js
+++ b/lib/webpagetest.js
@@ -93,6 +93,7 @@ function get(config, pathname, proxy, agent, callback, encoding) {
 
   if (encoding !== "binary") {
     options.headers["accept-encoding"] = "gzip,deflate";
+    options.headers["User-Agent"] = "WebpagetestNodeWrapper/v0.6.0";
   }
 
   if (agent) {


### PR DESCRIPTION
WPT server was throwing 403 error without `user-agent` headers. Added with this PR