### PR TITLE
Version bump

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-  - 10
+  - 17

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -109,7 +109,7 @@ function csvParser(data, callback) {
       var key, value;
       for (key in row) {
         value = row[key].replace(/<b>|<\/b>/g, '');
-        row[key] = entities.decode(value, 2);
+        row[key] = entities.decodeHTML(value, 2);
       }
       return row;
     }, callback.bind(this));

--- a/package.json
+++ b/package.json
@@ -31,12 +31,12 @@
   },
   "dependencies": {
     "commander": "^5.1.0",
-    "csv": "^5.3.2",
-    "entities": "^2.0.3",
-    "mocha": "^8.0.1",
+    "csv": "^6.2.2",
+    "entities": "^4.4.0",
+    "mocha": "^10.1.0",
     "xml2js": "^0.4.23"
   },
   "devDependencies": {
-    "nock": "^12.0.3"
+    "nock": "^13.2.9"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "webpagetest": "bin/webpagetest"
   },
   "scripts": {
-    "test": "./node_modules/mocha/bin/mocha -R spec test/*-test.js"
+    "test": "mocha -R spec test/*-test.js"
   },
   "engines": {
     "node": ">=10.18.1"


### PR DESCRIPTION
Travis CI will now run on version 17 of node
and all modules except commander (no red errors) are updated

https://github.com/WebPageTest/webpagetest-api/issues/166