### PR TITLE
Passing API key with headers

### DIFF
--- a/lib/webpagetest.js
+++ b/lib/webpagetest.js
@@ -92,6 +92,7 @@ function get(config, pathname, proxy, agent, callback, encoding) {
   }
 
   if (encoding !== "binary") {
+    options.headers["X-WPT-API-KEY"] = this.config.key;
     options.headers["accept-encoding"] = "gzip,deflate";
     options.headers["User-Agent"] = "WebpagetestNodeWrapper/v0.6.0";
   }
@@ -338,9 +339,10 @@ function getTestBalance(options, callback) {
   options = options === callback ? undefined : options;
 
   var query = helper.setQuery(mapping.commands.testBalance, options);
-  if (!query.k && this.config.key) {
-    query.k = this.config.key;
-  }
+  // API key (to pass with the parans) (depricated)
+  // if (!query.k && this.config.key) {
+  //   query.k = this.config.key;
+  // }
   return api.call(this, paths.testBalance, callback, query, options);
 }
 
@@ -366,10 +368,10 @@ function runTest(what, options, callback) {
   // json output format
   query.f = "json";
 
-  // API key
-  if (!query.k && this.config.key) {
-    query.k = this.config.key;
-  }
+  // API key (to pass with the parans) (depricated)
+  // if (!query.k && this.config.key) {
+  //   query.k = this.config.key;
+  // }
 
   // synchronous tests with results
   var testId,


### PR DESCRIPTION
The key won't be passed by query params anymore it will be passed with the headers